### PR TITLE
Associate table name in logs

### DIFF
--- a/gallon/input_dynamodb.go
+++ b/gallon/input_dynamodb.go
@@ -39,6 +39,11 @@ func NewInputPluginDynamoDb(
 var _ InputPlugin = &InputPluginDynamoDb{}
 
 func (p *InputPluginDynamoDb) ReplaceLogger(logger logr.Logger) {
+	if p.tableName != "" {
+		p.logger = logger.WithValues("table", p.tableName)
+		return
+	}
+
 	p.logger = logger
 }
 

--- a/gallon/input_sql.go
+++ b/gallon/input_sql.go
@@ -82,6 +82,11 @@ func NewInputPluginSql(
 var _ InputPlugin = &InputPluginSql{}
 
 func (p *InputPluginSql) ReplaceLogger(logger logr.Logger) {
+	if p.tableName != "" {
+		p.logger = logger.WithValues("table", p.tableName)
+		return
+	}
+
 	p.logger = logger
 }
 

--- a/gallon/output_bigquery.go
+++ b/gallon/output_bigquery.go
@@ -60,6 +60,19 @@ func (w bqRecordWrapper) Save() (row map[string]bigquery.Value, insertID string,
 var _ OutputPlugin = &OutputPluginBigQuery{}
 
 func (p *OutputPluginBigQuery) ReplaceLogger(logger logr.Logger) {
+	values := []any{}
+	if p.datasetId != "" {
+		values = append(values, "dataset", p.datasetId)
+	}
+	if p.tableId != "" {
+		values = append(values, "table", p.tableId)
+	}
+
+	if len(values) > 0 {
+		p.logger = logger.WithValues(values...)
+		return
+	}
+
 	p.logger = logger
 }
 


### PR DESCRIPTION
## Summary
- scope DynamoDB/SQL input loggers with the table name so extract logs show the source table
- add dataset/table context to BigQuery output logger so load/copy logs identify the destination

Closes #26