### PR TITLE
Add support for NULL values in DynamoDB number fields

### DIFF
--- a/gallon/input_dynamodb.go
+++ b/gallon/input_dynamodb.go
@@ -126,6 +126,11 @@ type InputPluginDynamoDbConfigSchemaColumn struct {
 }
 
 func (c InputPluginDynamoDbConfigSchemaColumn) getValue(v types.AttributeValue) (any, error) {
+	// Handle NULL for all types
+	if _, ok := v.(*types.AttributeValueMemberNULL); ok {
+		return nil, nil
+	}
+
 	switch c.Type {
 	case "string":
 		value, ok := v.(*types.AttributeValueMemberS)

--- a/gallon/input_dynamodb_test.go
+++ b/gallon/input_dynamodb_test.go
@@ -30,7 +30,7 @@ func TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullNumber(t *testing.T)
 			columnType:  "number",
 			value:       &types.AttributeValueMemberNULL{Value: true},
 			expected:    nil,
-			expectError: true, // 現在の実装ではエラーになる（修正後はfalseになるべき）
+			expectError: false, // NULL値はnilとして正しく処理される
 		},
 		{
 			name:        "string with valid value",
@@ -44,7 +44,7 @@ func TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullNumber(t *testing.T)
 			columnType:  "string",
 			value:       &types.AttributeValueMemberNULL{Value: true},
 			expected:    nil,
-			expectError: true, // 現在の実装ではエラーになる（修正後はfalseになるべき）
+			expectError: false, // NULL値はnilとして正しく処理される
 		},
 		{
 			name:        "boolean with valid value",
@@ -58,7 +58,7 @@ func TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullNumber(t *testing.T)
 			columnType:  "boolean",
 			value:       &types.AttributeValueMemberNULL{Value: true},
 			expected:    nil,
-			expectError: true, // 現在の実装ではエラーになる（修正後はfalseになるべき）
+			expectError: false, // NULL値はnilとして正しく処理される
 		},
 		{
 			name:        "any with NULL value",
@@ -119,11 +119,20 @@ func TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullInNestedObject(t *te
 	}
 
 	result, err := schema.getValue(value)
-	if err == nil {
-		t.Logf("Result: %v", result)
-		t.Log("Note: This test currently expects error. After fix, it should return {name: Alice, age: nil}")
-	} else {
-		t.Logf("Got expected error (current behavior): %v", err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", result)
+	}
+
+	if resultMap["name"] != "Alice" {
+		t.Errorf("expected name to be 'Alice', got %v", resultMap["name"])
+	}
+	if resultMap["age"] != nil {
+		t.Errorf("expected age to be nil, got %v", resultMap["age"])
 	}
 }
 
@@ -146,10 +155,25 @@ func TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullInArray(t *testing.T
 	}
 
 	result, err := schema.getValue(value)
-	if err == nil {
-		t.Logf("Result: %v", result)
-		t.Log("Note: This test currently expects error. After fix, it should return [1, nil, 3]")
-	} else {
-		t.Logf("Got expected error (current behavior): %v", err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resultSlice, ok := result.([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", result)
+	}
+
+	if len(resultSlice) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(resultSlice))
+	}
+	if resultSlice[0] != "1" {
+		t.Errorf("expected first element to be '1', got %v", resultSlice[0])
+	}
+	if resultSlice[1] != nil {
+		t.Errorf("expected second element to be nil, got %v", resultSlice[1])
+	}
+	if resultSlice[2] != "3" {
+		t.Errorf("expected third element to be '3', got %v", resultSlice[2])
 	}
 }

--- a/gallon/input_dynamodb_test.go
+++ b/gallon/input_dynamodb_test.go
@@ -1,0 +1,155 @@
+package gallon
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+func TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullNumber(t *testing.T) {
+	// Test case: number型のフィールドにNULLが入っている場合
+	// 現状: エラーになる
+	// 期待: nilを返すべき
+
+	tests := []struct {
+		name        string
+		columnType  string
+		value       types.AttributeValue
+		expected    any
+		expectError bool
+	}{
+		{
+			name:        "number with valid value",
+			columnType:  "number",
+			value:       &types.AttributeValueMemberN{Value: "42"},
+			expected:    "42",
+			expectError: false,
+		},
+		{
+			name:        "number with NULL value",
+			columnType:  "number",
+			value:       &types.AttributeValueMemberNULL{Value: true},
+			expected:    nil,
+			expectError: true, // 現在の実装ではエラーになる（修正後はfalseになるべき）
+		},
+		{
+			name:        "string with valid value",
+			columnType:  "string",
+			value:       &types.AttributeValueMemberS{Value: "hello"},
+			expected:    "hello",
+			expectError: false,
+		},
+		{
+			name:        "string with NULL value",
+			columnType:  "string",
+			value:       &types.AttributeValueMemberNULL{Value: true},
+			expected:    nil,
+			expectError: true, // 現在の実装ではエラーになる（修正後はfalseになるべき）
+		},
+		{
+			name:        "boolean with valid value",
+			columnType:  "boolean",
+			value:       &types.AttributeValueMemberBOOL{Value: true},
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "boolean with NULL value",
+			columnType:  "boolean",
+			value:       &types.AttributeValueMemberNULL{Value: true},
+			expected:    nil,
+			expectError: true, // 現在の実装ではエラーになる（修正後はfalseになるべき）
+		},
+		{
+			name:        "any with NULL value",
+			columnType:  "any",
+			value:       &types.AttributeValueMemberNULL{Value: true},
+			expected:    nil,
+			expectError: false, // anyタイプは現在もNULLをサポートしている
+		},
+		{
+			name:        "any with number value",
+			columnType:  "any",
+			value:       &types.AttributeValueMemberN{Value: "123"},
+			expected:    float64(123),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := InputPluginDynamoDbConfigSchemaColumn{
+				Type: tt.columnType,
+			}
+
+			result, err := schema.getValue(tt.value)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got nil, result: %v", result)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("expected %v (%T), got %v (%T)", tt.expected, tt.expected, result, result)
+				}
+			}
+		})
+	}
+}
+
+func TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullInNestedObject(t *testing.T) {
+	// Test case: object内のnumber型フィールドにNULLが入っている場合
+	schema := InputPluginDynamoDbConfigSchemaColumn{
+		Type: "object",
+		Properties: map[string]InputPluginDynamoDbConfigSchemaColumn{
+			"name": {Type: "string"},
+			"age":  {Type: "number"},
+		},
+	}
+
+	// ageがNULLのオブジェクト
+	value := &types.AttributeValueMemberM{
+		Value: map[string]types.AttributeValue{
+			"name": &types.AttributeValueMemberS{Value: "Alice"},
+			"age":  &types.AttributeValueMemberNULL{Value: true},
+		},
+	}
+
+	result, err := schema.getValue(value)
+	if err == nil {
+		t.Logf("Result: %v", result)
+		t.Log("Note: This test currently expects error. After fix, it should return {name: Alice, age: nil}")
+	} else {
+		t.Logf("Got expected error (current behavior): %v", err)
+	}
+}
+
+func TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullInArray(t *testing.T) {
+	// Test case: array内のnumber型アイテムにNULLが入っている場合
+	schema := InputPluginDynamoDbConfigSchemaColumn{
+		Type: "array",
+		Items: &InputPluginDynamoDbConfigSchemaColumn{
+			Type: "number",
+		},
+	}
+
+	// NULLを含む配列
+	value := &types.AttributeValueMemberL{
+		Value: []types.AttributeValue{
+			&types.AttributeValueMemberN{Value: "1"},
+			&types.AttributeValueMemberNULL{Value: true},
+			&types.AttributeValueMemberN{Value: "3"},
+		},
+	}
+
+	result, err := schema.getValue(value)
+	if err == nil {
+		t.Logf("Result: %v", result)
+		t.Log("Note: This test currently expects error. After fix, it should return [1, nil, 3]")
+	} else {
+		t.Logf("Got expected error (current behavior): %v", err)
+	}
+}

--- a/test/dynamodb/dynamo_test.go
+++ b/test/dynamodb/dynamo_test.go
@@ -544,6 +544,148 @@ out:
 	}
 }
 
+func Test_dynamodb_null_number(t *testing.T) {
+	// Prepare test data - number型のフィールドにNULLが入っている場合のテスト
+	tableName := "null_number_test"
+	ctx := context.Background()
+
+	// Create table
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String(tableName),
+		AttributeDefinitions: []types.AttributeDefinition{
+			{
+				AttributeName: aws.String("id"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		KeySchema: []types.KeySchemaElement{
+			{
+				AttributeName: aws.String("id"),
+				KeyType:       types.KeyTypeHash,
+			},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create table: %v", err)
+	}
+
+	// Insert test data with NULL number field
+	// レコード1: ageがnumber値
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"id":   &types.AttributeValueMemberS{Value: "user1"},
+			"name": &types.AttributeValueMemberS{Value: "Alice"},
+			"age":  &types.AttributeValueMemberN{Value: "30"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to insert data: %v", err)
+	}
+
+	// レコード2: ageがNULL
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"id":   &types.AttributeValueMemberS{Value: "user2"},
+			"name": &types.AttributeValueMemberS{Value: "Bob"},
+			"age":  &types.AttributeValueMemberNULL{Value: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to insert data: %v", err)
+	}
+
+	// レコード3: ageフィールドが存在しない
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"id":   &types.AttributeValueMemberS{Value: "user3"},
+			"name": &types.AttributeValueMemberS{Value: "Charlie"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to insert data: %v", err)
+	}
+
+	// Prepare configuration
+	configYml := fmt.Sprintf(`
+in:
+  type: dynamodb
+  table: %s
+  endpoint: %v
+  schema:
+    id:
+      type: string
+    name:
+      type: string
+    age:
+      type: number
+out:
+  type: file
+  filepath: ./null_number_output.jsonl
+  format: jsonl
+`, tableName, endpoint)
+
+	defer func() {
+		os.Remove("./null_number_output.jsonl")
+	}()
+
+	// Run Gallon
+	if err := cmd.RunGallon([]byte(configYml)); err != nil {
+		t.Fatalf("Failed to run Gallon: %s", err)
+	}
+
+	// Validate output file
+	jsonl, err := os.ReadFile("./null_number_output.jsonl")
+	if err != nil {
+		t.Fatalf("Failed to read output file: %s", err)
+	}
+
+	lines := strings.Split(string(jsonl), "\n")
+	// Filter empty lines
+	var validLines []string
+	for _, line := range lines {
+		if line != "" {
+			validLines = append(validLines, line)
+		}
+	}
+
+	// 全3レコードが正常に処理されることを期待
+	if len(validLines) != 3 {
+		t.Fatalf("Expected 3 records, got %d. Lines: %v", len(validLines), validLines)
+	}
+
+	// 各レコードの検証
+	for _, line := range validLines {
+		var data map[string]any
+		if err := json.Unmarshal([]byte(line), &data); err != nil {
+			t.Errorf("Could not unmarshal JSON: %s, line: %s", err, line)
+			continue
+		}
+
+		id := data["id"].(string)
+		switch id {
+		case "user1":
+			// ageは数値の文字列
+			if data["age"] != "30" {
+				t.Errorf("Expected age to be '30', got %v", data["age"])
+			}
+		case "user2":
+			// ageはNULL -> nilになるべき
+			if data["age"] != nil {
+				t.Errorf("Expected age to be nil for user2, got %v", data["age"])
+			}
+		case "user3":
+			// ageフィールドは存在しない
+			if _, exists := data["age"]; exists {
+				t.Errorf("Expected age to not exist for user3, got %v", data["age"])
+			}
+		}
+	}
+}
+
 func Test_dynamodb_rename_columns(t *testing.T) {
 	configYml := fmt.Sprintf(`
 in:


### PR DESCRIPTION
## Summary
This PR adds support for handling NULL values in DynamoDB fields, particularly for number types. Previously, the code would error when encountering NULL values in typed fields (number, string, boolean). After this change, NULL values are properly handled and converted to nil.

## Changes Made
- **Added comprehensive unit tests** (`gallon/input_dynamodb_test.go`):
  - `TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullNumber`: Tests NULL handling for number, string, boolean, and any types
  - `TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullInNestedObject`: Tests NULL values within nested objects
  - `TestInputPluginDynamoDbConfigSchemaColumn_getValue_NullInArray`: Tests NULL values within arrays

- **Added integration test** (`test/dynamodb/dynamo_test.go`):
  - `Test_dynamodb_null_number`: End-to-end test that validates NULL number fields are properly processed through the entire pipeline
  - Tests three scenarios: valid number value, NULL value, and missing field

## Implementation Details
- The tests document the current behavior (errors on NULL) and expected behavior (returns nil)
- NULL values are now treated as valid nil values rather than errors for typed fields
- The "any" type already supported NULL values and continues to work correctly
- NULL handling works consistently across simple fields, nested objects, and arrays

https://claude.ai/code/session_01Fy3dFbLW9auvqC3LPz2y9A