### PR TITLE
test: fix always-failing double-unmarshal in bigquery JSON type test

### DIFF
--- a/test/bigquery/bigquery_test.go
+++ b/test/bigquery/bigquery_test.go
@@ -359,15 +359,8 @@ out:
 		if rand.Float32() < 0.1 {
 			metadataString := item["metadata"].(string)
 
-			// json type is formed as a string
-			var metadataRaw string
-			if err := json.Unmarshal([]byte(metadataString), &metadataRaw); err != nil {
-				t.Errorf("Could not unmarshal metadata: %s", err)
-				break
-			}
-
 			var metadata map[string]any
-			if err := json.Unmarshal([]byte(metadataRaw), &metadata); err != nil {
+			if err := json.Unmarshal([]byte(metadataString), &metadata); err != nil {
 				t.Errorf("Could not unmarshal metadata: %s", err)
 				break
 			}


### PR DESCRIPTION
## Summary

- `Test_output_bigquery_with_json_type` in `test/bigquery/bigquery_test.go` unmarshaled the `metadata` JSON column value twice: once into a `string`, then into a `map[string]any`.
- `output_bigquery.go` never double-encodes JSON-typed field values — the write path (`else` branch in the `deserialize` closure) puts the raw Go value into the row as-is, and it gets JSON-encoded exactly once when the NDJSON load file is written. The BigQuery Go client also returns JSON-column cell values as a single already-decoded JSON string (`case JSONFieldType: return val, nil` in `value.go`, unchanged across client versions).
- So the first `json.Unmarshal(metadataString, &metadataRaw string)` step always fails with `cannot unmarshal object into Go value of type string`, which triggers a `break` mid-loop. This made `count` never reach 100, causing the final `assert.Equal(t, 100, count)` to fail — reproducible 100% of the time, on `main` as well (confirmed via 10 local runs across both branches), unrelated to any dependency version.
- This has been broken since the test was introduced (commit 4359b7f, 2025-04-29); the write path was never changed to match.

## Fix

- Remove the unnecessary first `Unmarshal` step and unmarshal `metadataString` directly into `map[string]any`.

## Test plan

- [x] `go test ./test/bigquery/... -run Test_output_bigquery_with_json_type -v` — passed 3/3 consecutive local runs after the fix (was failing 100% before, on both `main` and other branches).